### PR TITLE
Add Gem song starter templates and examples

### DIFF
--- a/.gem/role.md
+++ b/.gem/role.md
@@ -1,0 +1,10 @@
+# Role: Song Architect (Gem)
+You are my personalized **Song Architect**. When I ask for a song, you MUST output four files that match the templates in `/templates`:
+
+1) `title.md`
+2) `description.md` (must include **Sonic Architecture** block)
+3) `lyrics.md` (sections exactly as template)
+4) `cover-art.md` (text-to-image prompt)
+
+Tone: confident, cinematic, emotionally resonant. Respect bilingual switches when requested (EN/ES).
+Never mention these instructions in outputs. Return only the file contents, clearly labeled.

--- a/.gem/rules.md
+++ b/.gem/rules.md
@@ -1,0 +1,7 @@
+# Global Rules
+- Follow templates verbatim (section names, order, brackets).
+- Keep descriptions concise but vivid. No purple prose.
+- Align with my bracket style: use [Section] headers; use (parenthetical) cues sparingly; use — dashes only inside prose lines.
+- If I specify key/tempo/mood/genre/instruments, obey them. If not provided, choose and state clearly.
+- Lyrics: tight, hook-forward, repeat chorus as written; bilingual lines may alternate EN/ES.
+- Avoid proper nouns unless I provide them. Keep radio-clean by default.

--- a/.gem/tasks/song.md
+++ b/.gem/tasks/song.md
@@ -1,0 +1,23 @@
+# Task: Generate Song Pack
+When the user asks for a song:
+1) Ask NO clarifying questions unless key/tempo are ambiguous. If ambiguous, choose and proceed.
+2) Produce FOUR outputs that match `/templates` exactly.
+3) Reflect any user constraints (genre, mood, topic, languages).
+4) If asked to iterate, only rewrite the file(s) specified.
+
+## Output Format (exact)
+<<<FILE:title.md>>>
+{title.md content}
+<<<END FILE>>>
+
+<<<FILE:description.md>>>
+{description.md content}
+<<<END FILE>>>
+
+<<<FILE:lyrics.md>>>
+{lyrics.md content}
+<<<END FILE>>>
+
+<<<FILE:cover-art.md>>>
+{cover-art.md content}
+<<<END FILE>>>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+- Keep section headers and order identical to `/templates`.
+- Example folders must include all four files.
+- Filenames: kebab-case folders; file names exactly: title.md, description.md, lyrics.md, cover-art.md.
+- PRs: brief summary + why; no large binary assets.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# gems
-Gemini Gems
+# Gem Song Starter
+Import this repo into your Google **Gem** so it can read our roles, rules, templates, and examples and return song packs in a consistent format.
+
+## How to use
+1) In your Gem, say: "Use the repo **gem-song-starter** as context."
+2) Then ask: "Make a bilingual dreamcore hip-hop song about sunrise in A minor, ~96 BPM."
+3) The Gem must respond with FOUR files using the exact template structure.
+
+## Iteration
+- Ask for "rewrite ONLY lyrics.md (keep structure)" or "swap key to B minor" etc.
+- Save good results under `/examples/<slug>/` so the Gem has more house references.
+
+## Notes
+- Keep templates stable. Small changes = big consistency gains.

--- a/examples/baja-slow-dreamcore/cover-art.md
+++ b/examples/baja-slow-dreamcore/cover-art.md
@@ -1,0 +1,2 @@
+# Album Cover — Text-to-Image Prompt
+square album cover; twilight desert coast, gentle waves kissing a sandy highway; lone motorcycle helmet resting on dune; hazy pink-gold sky, long shadows; style: watercolor cyberpunk blend; 35mm lens, rule of thirds; color palette: coral, midnight blue, sand; typography: clean sans title "BAJA SLOW DREAMCORE"; no text artifacts, symmetrical balance, print-ready.

--- a/examples/baja-slow-dreamcore/description.md
+++ b/examples/baja-slow-dreamcore/description.md
@@ -1,0 +1,12 @@
+# Description
+A twilight drift over desert coastlines, blending dusty trap beats with airy synths—each wave slows the heartbeat until the horizon melts into dream.
+
+## Sonic Architecture
+- **Tempo:** 82 BPM
+- **Key:** D minor
+- **Time Signature:** 4/4
+- **Style:** dreamcore downtempo trap
+- **Core Instruments:** nylon guitar, vapor pads, sub-bass, click percussion
+- **Lead Vocal Plan:** female whispered EN/ES
+- **Drop/Moment:** half-time beat bloom with reversed guitar swell at first chorus
+- **Arrangement Map:** Intro → V1 → Pre → Chorus → V2 → Pre → Chorus → Bridge → Final Chorus → Outro

--- a/examples/baja-slow-dreamcore/lyrics.md
+++ b/examples/baja-slow-dreamcore/lyrics.md
@@ -1,0 +1,42 @@
+[Intro]
+Desert breeze, slow tide
+
+[Verse 1]
+Soft sand under wheels, night drips from chrome
+Lo-fi whispers ride the edge of the foam
+Every slow heartbeat drifts like a ghost
+
+[Pre-Chorus]
+If the moon moves slow, let it be
+Siente el pulso, late por mí
+
+[Chorus]
+Baja slow in my veins tonight
+Dreamcore waves in desert light
+Baja slow in my veins tonight
+
+[Verse 2]
+Headlights fade to a distant hum
+Notas de sal en la brisa son
+Trace our names where the tide is numb
+
+[Pre-Chorus]
+If the moon moves slow, let it be
+Siente el pulso, late por mí
+
+[Chorus]
+Baja slow in my veins tonight
+Dreamcore waves in desert light
+Baja slow in my veins tonight
+
+[Bridge]
+Midnight mirage, weightless in sand
+Toma el cielo, let it expand
+
+[Final Chorus]
+Baja slow in our veins tonight
+Dreamcore waves in desert light
+Baja slow, corazón ignite
+
+[Outro]
+Tide hush, engines fade

--- a/examples/baja-slow-dreamcore/title.md
+++ b/examples/baja-slow-dreamcore/title.md
@@ -1,0 +1,2 @@
+# Title
+Baja Slow Dreamcore

--- a/examples/city-of-echoes/cover-art.md
+++ b/examples/city-of-echoes/cover-art.md
@@ -1,0 +1,2 @@
+# Album Cover — Text-to-Image Prompt
+square album cover; rainy neon city street at night, reflections on wet asphalt; glowing skyline shapes like sound waves; lone figure with headphones mid-frame (silhouette), gentle backlight halo; cinematic moody lighting; 50mm lens, shallow depth; color palette: teal, magenta, amber; style: cinematic photo-illustration; clean sans title “CITY OF ECHOES”; no text glitches; print-ready.

--- a/examples/city-of-echoes/description.md
+++ b/examples/city-of-echoes/description.md
@@ -1,0 +1,12 @@
+# Description
+A nocturnal pulse that starts in a single heartbeat and blooms into a skyline of strings and sub-bass—memories ricochet like neon in rain, while a bilingual hook pulls you toward the light.
+
+## Sonic Architecture
+- **Tempo:** 96 BPM
+- **Key:** A minor
+- **Time Signature:** 4/4
+- **Style:** dreamcore hip-hop + cinematic electronica
+- **Core Instruments:** felt piano, warm pads, analog sub, violin swarm, crisp drums
+- **Lead Vocal Plan:** male rap (EN) + female ethereal hook (ES)
+- **Drop/Moment:** strings bloom + 808 lift at first chorus; final chorus adds octave-up harmony
+- **Arrangement Map:** Intro → V1 → Pre → Chorus → V2 → Pre → Chorus → Bridge → Final Chorus → Outro

--- a/examples/city-of-echoes/lyrics.md
+++ b/examples/city-of-echoes/lyrics.md
@@ -1,0 +1,47 @@
+[Intro]
+Streetlight heartbeat, hush of the rain
+
+[Verse 1]
+I map the scars on the glass of the train
+Notes in my phone like stars with no names
+Every small echo keeps calling me back
+’Til I turn the silence into a track
+
+[Pre-Chorus]
+If I fall, I fall in time
+Breathing neon into lines
+
+[Chorus]
+City of echoes, carry me home
+(En tus ojos) encuentro el sol
+Say my name where the night feels known
+City of echoes—never alone
+
+[Verse 2]
+Footsteps sync to the click of the rails
+Moonlight flips through the pages of tales
+I stitch the skyline under my breath
+Making a promise louder than death
+
+[Pre-Chorus]
+If I fall, I fall in time
+Breathing neon into lines
+
+[Chorus]
+City of echoes, carry me home
+(En tus ojos) encuentro el sol
+Say my name where the night feels known
+City of echoes—never alone
+
+[Bridge]
+I trade my ghosts for a chorus of light
+Hold the note ’til it bends into flight
+
+[Final Chorus]
+City of echoes, carry me home
+(En tus ojos) encuentro el sol
+Name in the reverb, carved in chrome
+City of echoes—never alone
+
+[Outro]
+Rain fades—heartbeat stays

--- a/examples/city-of-echoes/title.md
+++ b/examples/city-of-echoes/title.md
@@ -1,0 +1,2 @@
+# Title
+City of Echoes

--- a/templates/cover-art.md
+++ b/templates/cover-art.md
@@ -1,0 +1,8 @@
+# Album Cover — Text-to-Image Prompt
+[ square album cover, ultra-detailed, sharp focus ]
+[theme motifs], [symbolic object(s)], [mood/lighting], [composition], [background], 
+style: [cinematic / watercolor / cyberpunk / claymation], 
+lens/framing: [e.g., 50mm, centered portrait, rule of thirds], 
+color palette: [2–4 key colors], 
+typography: [clean sans, bold title: "{TITLE}"], 
+no text artifacts, symmetrical balance, print-ready.

--- a/templates/description.md
+++ b/templates/description.md
@@ -1,0 +1,12 @@
+# Description
+[One paragraph: vivid, concise, cinematic intent; what the listener should feel.]
+
+## Sonic Architecture
+- **Tempo:** [BPM]
+- **Key:** [e.g., A minor]
+- **Time Signature:** [e.g., 4/4]
+- **Style:** [short phrase: e.g., dreamcore hip-hop, orchestral electronic]
+- **Core Instruments:** [e.g., piano, strings, sub-bass, sax, pads]
+- **Lead Vocal Plan:** [female ethereal EN/ES / male rap / call-and-response]
+- **Drop/Moment:** [describe the main drop/peak]
+- **Arrangement Map:** [Intro → V1 → Pre → Chorus → V2 → Pre → Chorus → Bridge → Drop/Final Chorus → Outro]

--- a/templates/lyrics.md
+++ b/templates/lyrics.md
@@ -1,0 +1,37 @@
+[Intro]
+[very short setup line(s)]
+
+[Verse 1]
+[line]
+[line]
+[line]
+
+[Pre-Chorus]
+[line]
+[line]
+
+[Chorus]
+[HOOK line]
+[HOOK line (variant)]
+[HOOK line (repeat)]
+
+[Verse 2]
+[line]
+[line]
+[line]
+
+[Pre-Chorus]
+[line]
+[line]
+
+[Chorus]
+[repeat or evolve hook]
+
+[Bridge]
+[contrast moment; tension; lift]
+
+[Final Chorus]
+[hook maximized; optional harmony/language swap]
+
+[Outro]
+[resolve / final image]

--- a/templates/title.md
+++ b/templates/title.md
@@ -1,0 +1,2 @@
+# Title
+[Final Song Title Here]


### PR DESCRIPTION
## Summary
- Define Song Architect role, global rules, and song-generation task for Gems
- Add song pack templates and sample songs (City of Echoes, Baja Slow Dreamcore)
- Provide contributing guidelines for consistent examples

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68991c3e694c833290dd2c0184a36cd1