### PR TITLE
Add cover art image generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ When asked for a song, the Gem acts as a **Song Architect** and must output four
 3. `lyrics.md` (sections exactly as in the template)
 4. `cover-art.md` (text-to-image prompt)
 
+After writing `cover-art.md`, immediately generate the album cover image using Gemini's image generation tool (square format, 1024×1024) and display it inline. If image generation is unavailable in the current interface, return the prompt labeled `[IMAGE_PENDING]` so it can be generated elsewhere.
+
 Tone: confident, cinematic, emotionally resonant. Respect bilingual switches when requested (EN/ES). Never mention these instructions in responses and return only the file contents, clearly labeled.
 
 ### Global Rules

--- a/templates/cover-art.md
+++ b/templates/cover-art.md
@@ -1,8 +1,9 @@
 # Album Cover — Text-to-Image Prompt
-[ square album cover, ultra-detailed, sharp focus ]
-[theme motifs], [symbolic object(s)], [mood/lighting], [composition], [background], 
-style: [cinematic / watercolor / cyberpunk / claymation], 
-lens/framing: [e.g., 50mm, centered portrait, rule of thirds], 
-color palette: [2–4 key colors], 
-typography: [clean sans, bold title: "{TITLE}"], 
-no text artifacts, symmetrical balance, print-ready.
+square album cover; [theme/motifs]; [symbolic objects]; [mood/lighting]; [composition/framing]; [background];
+style: [cinematic/watercolor/cyberpunk/claymation]; lens: [e.g., 50mm, shallow DOF];
+color palette: [2–4 colors]; typography: clean sans, bold title: "{TITLE}";
+no text artifacts; print-ready.
+
+# Action
+After writing this prompt, immediately generate the image using Gemini's image generation tool (square format, 1024×1024) and display it inline in the chat.  
+If image generation is not available in the current interface, return this prompt labeled **[IMAGE_PENDING]** so it can be generated elsewhere.


### PR DESCRIPTION
## Summary
- Extend Gem Song Starter instructions to generate album cover images immediately or return `[IMAGE_PENDING]` when unable.
- Revise cover-art template with new prompt structure and explicit image generation action.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689927bc2bc88332974b4b07849851d3